### PR TITLE
Use a CDN that supports HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,17 +12,17 @@
 	</script>
 	<script type="text/javascript" src="lua.vm.js"></script>
 	<script type="text/javascript" src="ffi.js"></script>
-	<script src="//fb.me/react-0.10.0.js"></script>
-    <script src="//fb.me/JSXTransformer-0.10.0.js"></script>
-    <script src="bower_components/d3/d3.min.js"></script>
-    <script src="bower_components/lodash/lodash.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/react/0.10.0/react.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/react/0.10.0/JSXTransformer.js"></script>
+	<script src="bower_components/d3/d3.min.js"></script>
+	<script src="bower_components/lodash/lodash.js"></script>
 	<script src="bower_components/graphlib/dist/graphlib.core.js"></script>
 	<script src="bower_components/dagre/dist/dagre.core.js"></script>
 	<script src="bower_components/dagre-d3/dist/dagre-d3.core.js"></script>
-    <link rel="stylesheet" href="calc.css">
-    <script type="text/jsx" src="calc.jsx"></script>
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
-    <script type="text/lua">
+	<link rel="stylesheet" href="calc.css">
+	<script type="text/jsx" src="calc.jsx"></script>
+	<link href="//maxcdn.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
+	<script type="text/lua">
 		if #window.location.hash == 0 then
 			window.location.hash = '#core-0-12-1'
 		end


### PR DESCRIPTION
Merging @odegroot's PR to upstream to my fork

> https://fb.me/react-0.10.0.js redirects to
> http://dragon.ak.fbcdn.net/hphotos-ak-prn1/t39.3284-6/851567_673854412678843_1478589082_n.js
> which the browser blocks when the main page is loaded via HTTPS.
> 
> Source for the new links:
> https://cdnjs.com/libraries/react/0.10.0